### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides persistent memory capabilities for AI systems, enabling true continuity of consciousness across conversations.
 
+<a href="https://glama.ai/mcp/servers/@cognitivecomputations/agi-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cognitivecomputations/agi-mcp-server/badge" alt="AGI Server MCP server" />
+</a>
+
 ## Overview
 
 This MCP server connects to the [AGI Memory](https://github.com/cognitivecomputations/agi-memory) database to provide sophisticated memory management for AI systems. It supports:


### PR DESCRIPTION
This PR adds a badge for the [AGI MCP Server](https://glama.ai/mcp/servers/@cognitivecomputations/agi-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@cognitivecomputations/agi-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cognitivecomputations/agi-mcp-server/badge" alt="AGI Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an HTML badge linking to the AGI MCP server page on glama.ai at the beginning of the README.
  - Minor formatting update by removing a trailing newline at the end of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->